### PR TITLE
fix: throw proper exception when IP is blacklisted

### DIFF
--- a/source/bonbast-api.php
+++ b/source/bonbast-api.php
@@ -30,9 +30,14 @@ function bonbast()
      */
     preg_match('/data\:"(.*?)"/s', $homepage, $matches);
     if (!isset($matches[1])) {
-        throw new Exception(
-            "Couldn't extract the API key from homepage source."
-        );
+      // if error 403 exists in homepage response
+      if (strpos(strtolower($homepage), "error 403 (forbidden)") !== false) {
+        throw new Exception('The bonbast.com website returned 403 Forbidden response, probably your IP address is blacklisted.');
+      }
+
+      throw new Exception(
+          "Couldn't extract the API key from homepage source."
+      );
     }
 
     /**


### PR DESCRIPTION
Hey,
This PR helps in debugging process of #3 

When the IP is blocked, Google cloud will return the response below:

![image](https://user-images.githubusercontent.com/37535505/128632717-520b6083-0a80-4924-a0fa-eba5d3e9d24a.png)
