### PR TITLE
feat: rewrote bonbast-api.php file (OOP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Data will accessible in **Array** and **JSON** at **PHP** script. You can run ph
 ##### JSON
 
 ```json
-{"US Dollar":{"buy":"23700","sell":"23600"},"Euro":{"buy":"28065","sell":"27915"},"British Pound":{"buy":"31145","sell":"30945"},"Swiss Franc":{"buy":"26015","sell":"25865"},"Canadian Dollar":{"buy":"17820","sell":"17720"},"Australian Dollar":{"buy":"17110","sell":"17010"},"Swedish Krona":{"buy":"2725","sell":"2710"},"Norwegian Krone":{"buy":"2640","sell":"2625"},"Russian Ruble":{"buy":"323","sell":"320"},"Thai Baht":{"buy":"760","sell":"755"},"Singapore Dollar":{"buy":"17295","sell":"17195"},"Hong Kong Dollar":{"buy":"3060","sell":"3030"},"Azerbaijani Manat":{"buy":"13975","sell":"13875"},"Danish Krone":{"buy":"3765","sell":"3745"},"UAE Dirham":{"buy":"6450","sell":"6430"},"Turkish Lira":{"buy":"3245","sell":"3225"},"Chinese Yuan":{"buy":"3410","sell":"3390"},"KSA Riyal":{"buy":"6320","sell":"6290"},"Indian Rupee":{"buy":"316","sell":"314"},"Ringgit":{"buy":"5660","sell":"5630"},"Afghan Afghani":{"buy":"308","sell":"306"},"Kuwaiti Dinar":{"buy":"77585","sell":"77185"},"Bahraini Dinar":{"buy":"62875","sell":"62375"},"Omani Rial":{"buy":"61565","sell":"61265"},"Qatari Riyal":{"buy":"6510","sell":"6480"},"Gold Coins":{"buy":"Sell","sell":"Buy"},"Azadi":{"buy":"11,100,000","sell":"10,700,000"},"Emami":{"buy":"11,530,000","sell":"11,350,000"},"\u00bd Azadi":{"buy":"5,750,000","sell":"5,550,000"},"\u00bc Azadi":{"buy":"3,350,000","sell":"3,100,000"},"Gerami":{"buy":"1,750,000","sell":"1,550,000"}}
+{"US Dollar":{"sell":"25950","buy":"25850"},"Euro":{"sell":"30490","buy":"30340"},"British Pound":{"sell":"35960","buy":"35760"},"Swiss Franc":{"sell":"28240","buy":"28090"},"Canadian Dollar":{"sell":"20630","buy":"20530"},"Australian Dollar":{"sell":"19050","buy":"18950"},"Swedish Krona":{"sell":"2980","buy":"2965"},"Norwegian Krone":{"sell":"2905","buy":"2890"},"Russian Ruble":{"sell":"352","buy":"349"},"Thai Baht":{"sell":"775","buy":"770"},"Singapore Dollar":{"sell":"19125","buy":"19025"},"Hong Kong Dollar":{"sell":"3335","buy":"3305"},"Azerbaijani Manat":{"sell":"15240","buy":"15140"},"Armenian Dram":{"sell":"530","buy":"525"},"Danish Krone":{"sell":"4100","buy":"4080"},"UAE Dirham":{"sell":"7065","buy":"7045"},"Japanese Yen":{"sell":"2355","buy":"2345"},"Turkish Lira":{"sell":"3000","buy":"2980"},"Chinese Yuan":{"sell":"4000","buy":"3980"},"KSA Riyal":{"sell":"6920","buy":"6890"},"Indian Rupee":{"sell":"348","buy":"346"},"Ringgit":{"sell":"6135","buy":"6105"},"Afghan Afghani":{"sell":"325","buy":"323"},"Kuwaiti Dinar":{"sell":"86270","buy":"85870"},"Iraqi Dinar":{"sell":"1780","buy":"1770"},"Bahraini Dinar":{"sell":"68820","buy":"68320"},"Omani Rial":{"sell":"67400","buy":"67100"},"Qatari Riyal":{"sell":"7125","buy":"7095"},"Azadi":{"sell":"10700000","buy":"10450000"},"Emami":{"sell":"11220000","buy":"11080000"},"\u00bd Azadi":{"sell":"5780000","buy":"5680000"},"\u00bc Azadi":{"sell":"3600000","buy":"3480000"},"Gerami":{"sell":"2170000","buy":"2050000"},"Gold Gram":{"sell":"1083845"},"Gold Mithqal":{"sell":"4695000"},"Gold Ounce":{"sell":"1763.69"},"Bitcoin":{"sell":"45623.68"}}
 ```
 
 ##### PHP Array
@@ -25,190 +25,221 @@ Array
 (
     [US Dollar] => Array
         (
-            [buy] => 23700
-            [sell] => 23600
+            [sell] => 25950
+            [buy] => 25850
         )
 
     [Euro] => Array
         (
-            [buy] => 28065
-            [sell] => 27915
+            [sell] => 30490
+            [buy] => 30340
         )
 
     [British Pound] => Array
         (
-            [buy] => 31145
-            [sell] => 30945
+            [sell] => 35960
+            [buy] => 35760
         )
 
     [Swiss Franc] => Array
         (
-            [buy] => 26015
-            [sell] => 25865
+            [sell] => 28240
+            [buy] => 28090
         )
 
     [Canadian Dollar] => Array
         (
-            [buy] => 17820
-            [sell] => 17720
+            [sell] => 20630
+            [buy] => 20530
         )
 
     [Australian Dollar] => Array
         (
-            [buy] => 17110
-            [sell] => 17010
+            [sell] => 19050
+            [buy] => 18950
         )
 
     [Swedish Krona] => Array
         (
-            [buy] => 2725
-            [sell] => 2710
+            [sell] => 2980
+            [buy] => 2965
         )
 
     [Norwegian Krone] => Array
         (
-            [buy] => 2640
-            [sell] => 2625
+            [sell] => 2905
+            [buy] => 2890
         )
 
     [Russian Ruble] => Array
         (
-            [buy] => 323
-            [sell] => 320
+            [sell] => 352
+            [buy] => 349
         )
 
     [Thai Baht] => Array
         (
-            [buy] => 760
-            [sell] => 755
+            [sell] => 775
+            [buy] => 770
         )
 
     [Singapore Dollar] => Array
         (
-            [buy] => 17295
-            [sell] => 17195
+            [sell] => 19125
+            [buy] => 19025
         )
 
     [Hong Kong Dollar] => Array
         (
-            [buy] => 3060
-            [sell] => 3030
+            [sell] => 3335
+            [buy] => 3305
         )
 
     [Azerbaijani Manat] => Array
         (
-            [buy] => 13975
-            [sell] => 13875
+            [sell] => 15240
+            [buy] => 15140
+        )
+
+    [Armenian Dram] => Array
+        (
+            [sell] => 530
+            [buy] => 525
         )
 
     [Danish Krone] => Array
         (
-            [buy] => 3765
-            [sell] => 3745
+            [sell] => 4100
+            [buy] => 4080
         )
 
     [UAE Dirham] => Array
         (
-            [buy] => 6450
-            [sell] => 6430
+            [sell] => 7065
+            [buy] => 7045
+        )
+
+    [Japanese Yen] => Array
+        (
+            [sell] => 2355
+            [buy] => 2345
         )
 
     [Turkish Lira] => Array
         (
-            [buy] => 3245
-            [sell] => 3225
+            [sell] => 3000
+            [buy] => 2980
         )
 
     [Chinese Yuan] => Array
         (
-            [buy] => 3410
-            [sell] => 3390
+            [sell] => 4000
+            [buy] => 3980
         )
 
     [KSA Riyal] => Array
         (
-            [buy] => 6320
-            [sell] => 6290
+            [sell] => 6920
+            [buy] => 6890
         )
 
     [Indian Rupee] => Array
         (
-            [buy] => 316
-            [sell] => 314
+            [sell] => 348
+            [buy] => 346
         )
 
     [Ringgit] => Array
         (
-            [buy] => 5660
-            [sell] => 5630
+            [sell] => 6135
+            [buy] => 6105
         )
 
     [Afghan Afghani] => Array
         (
-            [buy] => 308
-            [sell] => 306
+            [sell] => 325
+            [buy] => 323
         )
 
     [Kuwaiti Dinar] => Array
         (
-            [buy] => 77585
-            [sell] => 77185
+            [sell] => 86270
+            [buy] => 85870
+        )
+
+    [Iraqi Dinar] => Array
+        (
+            [sell] => 1780
+            [buy] => 1770
         )
 
     [Bahraini Dinar] => Array
         (
-            [buy] => 62875
-            [sell] => 62375
+            [sell] => 68820
+            [buy] => 68320
         )
 
     [Omani Rial] => Array
         (
-            [buy] => 61565
-            [sell] => 61265
+            [sell] => 67400
+            [buy] => 67100
         )
 
     [Qatari Riyal] => Array
         (
-            [buy] => 6510
-            [sell] => 6480
-        )
-
-    [Gold Coins] => Array
-        (
-            [buy] => Sell
-            [sell] => Buy
+            [sell] => 7125
+            [buy] => 7095
         )
 
     [Azadi] => Array
         (
-            [buy] => 11,100,000
-            [sell] => 10,700,000
+            [sell] => 10700000
+            [buy] => 10450000
         )
 
     [Emami] => Array
         (
-            [buy] => 11,530,000
-            [sell] => 11,350,000
+            [sell] => 11220000
+            [buy] => 11080000
         )
 
     [½ Azadi] => Array
         (
-            [buy] => 5,750,000
-            [sell] => 5,550,000
+            [sell] => 5780000
+            [buy] => 5680000
         )
 
     [¼ Azadi] => Array
         (
-            [buy] => 3,350,000
-            [sell] => 3,100,000
+            [sell] => 3600000
+            [buy] => 3480000
         )
 
     [Gerami] => Array
         (
-            [buy] => 1,750,000
-            [sell] => 1,550,000
+            [sell] => 2170000
+            [buy] => 2050000
         )
 
+    [Gold Gram] => Array
+        (
+            [sell] => 1083845
+        )
+
+    [Gold Mithqal] => Array
+        (
+            [sell] => 4695000
+        )
+
+    [Gold Ounce] => Array
+        (
+            [sell] => 1763.69
+        )
+
+    [Bitcoin] => Array
+        (
+            [sell] => 45623.68
+        )
 )
 ```
 

--- a/example.php
+++ b/example.php
@@ -1,10 +1,25 @@
 <?php
 // Max Base
 // https://github.com/BaseMax/bonbast-api
-include "source/bonbast-api.php";
+require_once "source/bonbast-api.php";
 
-$prices=bonbast();
-// Display output
-print_r($prices);
-// Display JSON
-print json_encode($prices)."\n";
+try {
+  $api = new BonBast();
+  $prices = $api->fetchPrices();
+
+  // Display output
+  print_r($prices);
+
+  // Display JSON
+  echo json_encode($prices) . PHP_EOL;
+} catch (IPAddressBlockedException $e) {
+  die($e->getMessage());
+} catch (InvalidHTTPStatusException $e) {
+  die($e->getMessage());
+} catch (BadHomepageDataException $e) {
+  die($e->getMessage());
+} catch (InvalidApiKeyException $e) {
+  die($e->getMessage());
+} catch (Exception $e) {
+  die("Invalid exception: " . $e->getMessage());
+}

--- a/source/bonbast-api.php
+++ b/source/bonbast-api.php
@@ -3,153 +3,199 @@
  * @Name: bonbast-api
  * @Author: Max Base
  * @Repository: https://github.com/BaseMax/bonbast-api
- * @Date: Jul 15, 2020, 2020-08-07, 2021-08-01, 2021-08-02
+ * @Date: Jul 15, 2020, 2020-08-07, 2021-08-01, 2021-08-02, 2021-08-10
  */
-function bonbast()
-{
-    $user_agent =
-        "Mozilla/5.0(Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML,like Gecko) curlrome/68.0.3440.106 Mobile Safari/537.36";
+require_once "errors.php";
 
-    /**
-     * Fetch homepage
-     */
+class BonBast
+{
+  private $baseURI = "https://www.bonbast.com";
+
+  private $user_agent = "Mozilla/5.0(Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML,like Gecko) curlrome/68.0.3440.106 Mobile Safari/537.36";
+
+  /**
+   * How the response structure should be mapped
+   * Before returning it.
+   */
+  private $map = [
+    // Currency name, Sell key, Buy key
+    ["US Dollar", "usd1", "usd2"],
+    ["Euro", "eur1", "eur2"],
+    ["British Pound", "gbp1", "gbp2"],
+    ["Swiss Franc", "chf1", "chf2"],
+    ["Canadian Dollar", "cad1", "cad2"],
+    ["Australian Dollar", "aud1", "aud2"],
+    ["Swedish Krona", "sek1", "sek2"],
+    ["Norwegian Krone", "nok1", "nok2"],
+    ["Russian Ruble", "rub1", "rub2"],
+    ["Thai Baht", "thb1", "thb2"],
+    ["Singapore Dollar", "sgd1", "sgd2"],
+    ["Hong Kong Dollar", "hkd1", "hkd2"],
+    ["Azerbaijani Manat", "azn1", "azn2"],
+    ["Armenian Dram", "amd1", "amd2"],
+    ["Danish Krone", "dkk1", "dkk2"],
+    ["UAE Dirham", "aed1", "aed2"],
+    ["Japanese Yen", "jpy1", "jpy2"],
+    ["Turkish Lira", "try1", "try2"],
+    ["Chinese Yuan", "cny1", "cny2"],
+    ["KSA Riyal", "sar1", "sar2"],
+    ["Indian Rupee", "inr1", "inr2"],
+    ["Ringgit", "myr1", "myr2"],
+    ["Afghan Afghani", "afn1", "afn2"],
+    ["Kuwaiti Dinar", "kwd1", "kwd2"],
+    ["Iraqi Dinar", "iqd1", "iqd2"],
+    ["Bahraini Dinar", "bhd1", "bhd2"],
+    ["Omani Rial", "omr1", "omr2"],
+    ["Qatari Riyal", "qar1", "qar2"],
+
+    // Coin name, Sell key, Buy key.
+    ["Azadi", "azadi1", "azadi12"],
+    ["Emami", "emami1", "emami12"],
+    ["½ Azadi", "azadi1_2", "azadi1_22"],
+    ["¼ Azadi", "azadi1_4", "azadi1_42"],
+    ["Gerami", "azadi1g", "azadi1g2"],
+
+    // Gold name, Sell key
+    ["Gold Gram", "gol18"],
+    ["Gold Mithqal", "mithqal"],
+    ["Gold Ounce", "ounce"],
+
+    // Digital currency name, Sell key
+    ["Bitcoin", "bitcoin"],
+  ];
+
+  function fetchPrices()
+  {
+    $homepage = $this->requestFetchHomePage();
+    $key = $this->extractKeyFromHomePage($homepage);
+    $json_object = $this->requestFetchPrices($key);
+    return $this->mapResponse($json_object);
+  }
+
+  /**
+   * Send HTTP Request to fetch homepage
+   */
+  private function requestFetchHomePage()
+  {
     $curl = curl_init();
     curl_setopt_array($curl, [
-        CURLOPT_CUSTOMREQUEST => "GET",
-        CURLOPT_RETURNTRANSFER => true,
-        CURLOPT_URL => "https://www.bonbast.com",
-        CURLOPT_SSL_VERIFYHOST => false,
-        CURLOPT_SSL_VERIFYPEER => false,
-        CURLOPT_HTTPHEADER => ["user-agent: " . $user_agent],
+      CURLOPT_CUSTOMREQUEST => "GET",
+      CURLOPT_RETURNTRANSFER => true, // return body
+      CURLOPT_HEADER => true, // return status code
+      CURLOPT_URL => $this->baseURI,
+      CURLOPT_SSL_VERIFYHOST => false,
+      CURLOPT_SSL_VERIFYPEER => false,
+      CURLOPT_HTTPHEADER => ["user-agent: " . $this->user_agent],
     ]);
     $homepage = curl_exec($curl);
+    $HTTPCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
     curl_close($curl);
 
+    $this->validateHTTPStatusCode($HTTPCode);
+
+    return $homepage;
+  }
+
+  /**
+   * Extract key from homepage response
+   */
+  private function extractKeyFromHomePage($homepage)
+  {
     /**
      * Extract "body parameters" which are hard coded in homepage response
      */
     preg_match('/data\:"(.*?)"/s', $homepage, $matches);
-    if (!isset($matches[1])) {
-      // if error 403 exists in homepage response
-      if (strpos(strtolower($homepage), "error 403 (forbidden)") !== false) {
-        throw new Exception('The bonbast.com website returned 403 Forbidden response, probably your IP address is blacklisted.');
-      }
 
-      throw new Exception(
-          "Couldn't extract the API key from homepage source."
-      );
-    }
+    // Couldn't extract the API key from homepage source.
+    if (!isset($matches[1])) throw new BadHomepageDataException();
+    return $matches[1];
+  }
 
+  /**
+   * Send HTTP Request to fetch prices via bonbast.com API
+   */
+  private function requestFetchPrices($key)
+  {
     /**
      * Request to get prices
      */
     $curl = curl_init();
     curl_setopt_array($curl, [
-        CURLOPT_CUSTOMREQUEST => "POST",
-        CURLOPT_RETURNTRANSFER => true,
-        CURLOPT_URL => "https://www.bonbast.com/json",
-        CURLOPT_SSL_VERIFYHOST => false,
-        CURLOPT_SSL_VERIFYPEER => false,
-        CURLOPT_TIMEOUT => 0,
-        CURLOPT_POSTFIELDS => "data=" . $matches[1] . "&webdriver=false",
-        CURLOPT_HTTPHEADER => [
-            "user-agent: " . $user_agent,
-            "content-type: application/x-www-form-urlencoded; charset=UTF-8",
-            "referer: https://www.bonbast.com/",
-            "Cookie: st_bb=0",
-        ],
+      CURLOPT_CUSTOMREQUEST => "POST",
+      CURLOPT_RETURNTRANSFER => true, // return body
+      CURLOPT_HEADER => true, // return status code
+      CURLOPT_URL => $this->baseURI . "/json",
+      CURLOPT_SSL_VERIFYHOST => false,
+      CURLOPT_SSL_VERIFYPEER => false,
+      CURLOPT_TIMEOUT => 0,
+      CURLOPT_POSTFIELDS => "data=" . $key . "&webdriver=false",
+      CURLOPT_HTTPHEADER => [
+        "user-agent: " . $this->user_agent,
+        "content-type: application/x-www-form-urlencoded; charset=UTF-8",
+        "referer: " . $this->baseURI . "/",
+        "Cookie: st_bb=0",
+      ],
     ]);
     $response = curl_exec($curl);
+    $HTTPCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
     curl_close($curl);
+
+    $this->validateHTTPStatusCode($HTTPCode);
+
+    // Then, after your curl_exec call:
+    $body = substr($response, curl_getinfo($curl, CURLINFO_HEADER_SIZE));
+
     // JSON decode response body
-    $json_object = @JSON_DECODE($response, true);
+    $json_object = @json_decode($body, true);
 
     /**
      * Check if the decoded JSON is empty
      */
-    if ($json_object === null) {
-        throw new Exception("Couldn't decode JSON response");
-    }
+    if ($json_object === null) throw new Exception("Couldn't decode JSON response");
 
     /**
      * If decoded JSON has "reset" field inside, means API request has failed.
      */
-    if (isset($json_object["reset"])) {
-        throw new Exception(
-            "Couldn't fetch the prices: API returned reset field!"
-        );
-    }
+    if (isset($json_object["reset"])) throw new InvalidApiKeyException();
 
-    /**
-     * How the response structure should be mapped
-     * Before returning it.
-     */
-    $map = [
-        // Currency name, Sell key, Buy key
-        ["US Dollar", "usd1", "usd2"],
-        ["Euro", "eur1", "eur2"],
-        ["British Pound", "gbp1", "gbp2"],
-        ["Swiss Franc", "chf1", "chf2"],
-        ["Canadian Dollar", "cad1", "cad2"],
-        ["Australian Dollar", "aud1", "aud2"],
-        ["Swedish Krona", "sek1", "sek2"],
-        ["Norwegian Krone", "nok1", "nok2"],
-        ["Russian Ruble", "rub1", "rub2"],
-        ["Thai Baht", "thb1", "thb2"],
-        ["Singapore Dollar", "sgd1", "sgd2"],
-        ["Hong Kong Dollar", "hkd1", "hkd2"],
-        ["Azerbaijani Manat", "azn1", "azn2"],
-        ["Armenian Dram", "amd1", "amd2"],
-        ["Danish Krone", "dkk1", "dkk2"],
-        ["UAE Dirham", "aed1", "aed2"],
-        ["Japanese Yen", "jpy1", "jpy2"],
-        ["Turkish Lira", "try1", "try2"],
-        ["Chinese Yuan", "cny1", "cny2"],
-        ["KSA Riyal", "sar1", "sar2"],
-        ["Indian Rupee", "inr1", "inr2"],
-        ["Ringgit", "myr1", "myr2"],
-        ["Afghan Afghani", "afn1", "afn2"],
-        ["Kuwaiti Dinar", "kwd1", "kwd2"],
-        ["Iraqi Dinar", "iqd1", "iqd2"],
-        ["Bahraini Dinar", "bhd1", "bhd2"],
-        ["Omani Rial", "omr1", "omr2"],
-        ["Qatari Riyal", "qar1", "qar2"],
+    return $json_object;
+  }
 
-        // Coin name, Sell key, Buy key.
-        ["Azadi", "azadi1", "azadi12"],
-        ["Emami", "emami1", "emami12"],
-        ["½ Azadi", "azadi1_2", "azadi1_22"],
-        ["¼ Azadi", "azadi1_4", "azadi1_42"],
-        ["Gerami", "azadi1g", "azadi1g2"],
-
-        // Gold name, Sell key
-        ["Gold Gram", "gol18"],
-        ["Gold Mithqal", "mithqal"],
-        ["Gold Ounce", "ounce"],
-
-        // Digital currency name, Sell key
-        ["Bitcoin", "bitcoin"],
-    ];
-
+  private function mapResponse($json_object)
+  {
     $prices = [];
 
-    for ($i = 0; $i < count($map); $i++) {
-        $name = $map[$i][0];
-        $sell_key = $map[$i][1];
-        $prices[$name] = [
-            "sell" => $json_object[$sell_key],
-        ];
+    for ($i = 0; $i < count($this->map); $i++) {
+      $name = $this->map[$i][0];
+      $sell_key = $this->map[$i][1];
+      $prices[$name] = [
+        "sell" => $json_object[$sell_key],
+      ];
 
-        // Check if this price name, has the "buy" field in map variable
-        if (isset($map[$i][2])) {
-            $buy_key = $map[$i][2];
-            $prices[$name]["buy"] = $json_object[$buy_key];
-        } else {
-            // This currency doesn't have "buy" key,
-            // Uncomment the line below to set default 0 value
-            // $prices[$name]["buy"] = 0;
-        }
+      // Check if this price name, has the "buy" field in map variable
+      if (isset($this->map[$i][2])) {
+        $buy_key = $this->map[$i][2];
+        $prices[$name]["buy"] = $json_object[$buy_key];
+      } else {
+        // This currency doesn't have "buy" key,
+        // Uncomment the line below to set default 0 value
+        // $prices[$name]["buy"] = 0;
+      }
     }
 
     return $prices;
+  }
+
+  private function validateHTTPStatusCode($code)
+  {
+    if (!in_array($code, [200, 201])) {
+      switch ($code) {
+        case 403:
+          throw new IPAddressBlockedException();
+
+        default:
+          throw new InvalidHTTPStatusException($code);
+      }
+    }
+  }
 }

--- a/source/errors.php
+++ b/source/errors.php
@@ -1,0 +1,24 @@
+<?php
+class IPAddressBlockedException extends Exception {
+  protected $message = "Your IP address is blacklisted by bonbast.com";
+  protected $code = 403;
+}
+
+class InvalidHTTPStatusException extends Exception {
+  protected $message = "The bonbast.com returned invalid HTTP status code";
+
+  function __construct($code) {
+    $this->code = $code;
+  }
+}
+
+class BadHomepageDataException extends Exception {
+  protected $message = "The bonbast.com website returned unsupported homepage response"
+    . PHP_EOL . "Please fill an issue in https://github.com/BaseMax/bonbast-api/issues/new";
+  protected $code = 500;
+}
+
+class InvalidApiKeyException extends Exception {
+  protected $message = "The bonbast.com API returned 'reset' field in response, which means the key is invalid!";
+  protected $code = 500;
+}


### PR DESCRIPTION
Hey @BaseMax,
You gave the idea to implement the caching feature [in this PR](https://github.com/BaseMax/bonbast-api/pull/4#issuecomment-894797788),
As I replied there, it is not possible if we don't migrate to OOP :)

To implement the key caching feature, everything has to be in a class to cache the key in the object's properties.

In this PR
- I rewrote the `bonbast-api.php` file, wrapped every function in the `BonBast` class.
- Refactored the `bonbast()` function, chunked its code into multiple private functions.
- Improved error handling by creating custom Exceptions, located in the `errors.php` file.
- Updated the `example.php` file and added the new API with its error handling instruction.
- Updated the `README.md` file and put the fresh sample data.

Unfortunately, I don't have enough free time to write [PHPDoc](https://docs.phpdoc.org/3.0/guide/references/phpdoc/index.html) for the private methods.
I leave it to you!

I've not added the key caching feature, and this PR is just migration to OOP API!